### PR TITLE
ci: 'publish' github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,52 @@
+name: "🚀 Publish"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: 🚀 publish
+    runs-on: ubuntu-latest
+
+    steps:
+
+      # Checkout repository
+      - name: 📁 Checkout Repository
+        uses: actions/checkout@v3
+
+      # Setup Node.js
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.3.0
+
+      # Install Pnpm
+      - name: ⬇️ Install Pnpm  
+        uses: pnpm/action-setup@v2.2.2
+        with:
+          run_install: false
+
+      - name: 📒 Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - name: 💾 Cache pnpm store
+        uses: actions/cache@v3        
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: 📦 Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: 🔨 Build  
+        run: pnpm build
+
+      - name: 🚀 Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Add github actions for automatic publish to npm registry

* publish: When a new release is published to github, it should publish the new version to npm

closes: #5 